### PR TITLE
Add copyright to lisence file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,7 @@
 This software is released under the MIT license:
 
+Copyright (c) 2012-2015 Thorsten Lorenz
+
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
 the Software without restriction, including without limitation the rights to


### PR DESCRIPTION
Hi.

I found a little problem in your license text.

MIT license full text should be contain copyright text(like : http://opensource.org/licenses/MIT ), but I could not found in your repository.

So, I would like to add a copyright.

Could you take this proposal?
 