### PR TITLE
readdirp will stop walking the fs when paused

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,10 +34,12 @@
   "dependencies": {
     "graceful-fs": "^4.1.2",
     "minimatch": "^3.0.2",
-    "readable-stream": "^2.0.2"
+    "readable-stream": "^2.0.2",
+    "set-immediate-shim": "^1.0.1"
   },
   "devDependencies": {
     "nave": "^0.5.1",
+    "proxyquire": "^1.7.9",
     "tap": "1.3.2",
     "through2": "^2.0.0"
   },

--- a/stream-api.js
+++ b/stream-api.js
@@ -1,7 +1,6 @@
 'use strict';
 
-var si = typeof setImmediate !== 'undefined' ? setImmediate : function (fn) { setTimeout(fn, 0) };
-
+var si =  require('set-immediate-shim')
 var stream = require('readable-stream');
 var util = require('util');
 


### PR DESCRIPTION
This causes readdirp to enter a `setImmediate` loop while the stream is
paused preventing it from queuing up more actions to be replayed when
the stream is resumed.