### PR TITLE
Wait until the next tick to pause the stream

### DIFF
--- a/test/readdirp-stream.js
+++ b/test/readdirp-stream.js
@@ -252,16 +252,19 @@ test('\napi separately', function (t) {
         t.equals(data, processedData, 'emits the buffered data');
         t.ok(resumed, 'emits data only after it was resumed');
       })
-      .pause()
     
-    api.processEntry(processedData);
-    api.handleError(nonfatalError);
-    api.handleFatalError(fatalError);
+    process.nextTick(function() {
+      api.stream.pause();
+
+      api.processEntry(processedData);
+      api.handleError(nonfatalError);
+      api.handleFatalError(fatalError);
   
-    setTimeout(function () {
-      resumed = true;
-      api.stream.resume();
-    }, 1)
+      setTimeout(function () {
+        resumed = true;
+        api.stream.resume();
+      }, 1)
+    })
   })
 
 


### PR DESCRIPTION
Registering handlers on a stream with `on` causes resume to be called, but only on the next tick.

This leads to a race condition where the pause can happen before that delayed resume, which then resumes the stream earlier than we were expecting.