### PR TITLE
Deleting test files and examples from the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
     "filter"
   ],
   "main": "readdirp.js",
+  "files": [
+    "readdirp.js",
+    "stream-api.js"
+  ],
   "scripts": {
     "test-main": "(cd test && set -e; for t in ./*.js; do node $t; done)",
     "test-0.8": "nave use 0.8 npm run test-main",


### PR DESCRIPTION
Excludes unnecessary files from redist package. The average user does not need tests and examples in the package. They need developers.

About [README.md and LICENSE](https://docs.npmjs.com/files/package.json#files):
> Certain files are always included, regardless of settings:
>   * package.json
>   * README (and its variants)
>   * CHANGELOG (and its variants)
>   * LICENSE / LICENCE