### PR TITLE
Use svg badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# readdirp [![Build Status](https://secure.travis-ci.org/thlorenz/readdirp.png)](http://travis-ci.org/thlorenz/readdirp)
+# readdirp [![Build Status](https://secure.travis-ci.org/thlorenz/readdirp.svg)](http://travis-ci.org/thlorenz/readdirp)
 
 [![NPM](https://nodei.co/npm/readdirp.png?downloads=true&stars=true)](https://nodei.co/npm/readdirp/)
 


### PR DESCRIPTION
Replace the fuzzy png with a crisp svg

Previously
<img width="265" alt="screen shot 2016-06-22 at 4 56 50 pm" src="https://cloud.githubusercontent.com/assets/3477707/16287757/790b73b6-389a-11e6-9714-a1dbac19d1d1.png">

Now
<img width="265" alt="screen shot 2016-06-22 at 4 56 34 pm" src="https://cloud.githubusercontent.com/assets/3477707/16287755/7703bfa6-389a-11e6-8704-c15880821042.png">

