### PR TITLE
Bump minimatch version to avoid vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "graceful-fs": "^4.1.2",
-    "minimatch": "^3.0.2",
+    "minimatch": "^3.0.4",
     "readable-stream": "^2.0.2",
     "set-immediate-shim": "^1.0.1"
   },


### PR DESCRIPTION
minimatch < 3.0.4 uses an old version of brace-expansion, with a known vulnerability:
https://snyk.io/test/npm/brace-expansion/1.1.6